### PR TITLE
Remove Facebook and Twitter icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,6 @@ id: index
         <div class="col-sm-12 col-md-10 col-xs-12 social-media">
             <div class="row justify-content-center">
                 <a target="_blank" href="https://github.com/{{ site.github_username }}"><img class="social-icon" src="/img/github-icon.png"/></a>
-                <a target="_blank" href="https://www.facebook.com/{{ site.facebook_username }}"><img class="social-icon" src="/img/facebook-icon.png"/></a>
-                <a target="_blank" href="https://twitter.com/{{ site.twitter_username }}"><img class="social-icon" src="/img/twitter-icon.png"/></a>
                 <a target="_blank" href="https://instagram.com/{{ site.instagram_username }}"><img class="social-icon" src="/img/instagram-icon.png"/></a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- strip out Facebook and Twitter links from the about page

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840936ec9708325abbe84649022b44d